### PR TITLE
Encrypt mailbox credentials at rest

### DIFF
--- a/backend/internal/models/credential_crypto.go
+++ b/backend/internal/models/credential_crypto.go
@@ -1,0 +1,89 @@
+package models
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"io"
+	"os"
+	"strings"
+)
+
+const encryptedValuePrefix = "enc:v1:"
+
+func credentialKey() ([]byte, error) {
+	secret := os.Getenv("FIREMAIL_CREDENTIAL_KEY")
+	if secret == "" {
+		secret = os.Getenv("CREDENTIAL_ENCRYPTION_KEY")
+	}
+	if secret == "" {
+		secret = os.Getenv("JWT_SECRET")
+	}
+	if len(secret) < 24 {
+		return nil, errors.New("FIREMAIL_CREDENTIAL_KEY/CREDENTIAL_ENCRYPTION_KEY must be set and at least 24 characters")
+	}
+	sum := sha256.Sum256([]byte(secret))
+	return sum[:], nil
+}
+
+func isEncryptedValue(value string) bool {
+	return strings.HasPrefix(value, encryptedValuePrefix)
+}
+
+func EncryptCredential(value string) (string, error) {
+	if value == "" || isEncryptedValue(value) {
+		return value, nil
+	}
+	key, err := credentialKey()
+	if err != nil {
+		return "", err
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+	sealed := gcm.Seal(nonce, nonce, []byte(value), nil)
+	return encryptedValuePrefix + base64.RawURLEncoding.EncodeToString(sealed), nil
+}
+
+func DecryptCredential(value string) (string, error) {
+	if value == "" || !isEncryptedValue(value) {
+		return value, nil
+	}
+	key, err := credentialKey()
+	if err != nil {
+		return "", err
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(value, encryptedValuePrefix))
+	if err != nil {
+		return "", err
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+	if len(raw) < gcm.NonceSize() {
+		return "", errors.New("encrypted credential is too short")
+	}
+	nonce, ciphertext := raw[:gcm.NonceSize()], raw[gcm.NonceSize():]
+	plain, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return "", err
+	}
+	return string(plain), nil
+}

--- a/backend/internal/models/email_account.go
+++ b/backend/internal/models/email_account.go
@@ -3,6 +3,8 @@ package models
 import (
 	"encoding/json"
 	"time"
+
+	"gorm.io/gorm"
 )
 
 // EmailAccount 邮件账户模型
@@ -27,10 +29,10 @@ type EmailAccount struct {
 
 	// 认证信息（加密存储）
 	Username string `gorm:"size:100" json:"username,omitempty"`
-	Password string `gorm:"size:255" json:"-"` // 密码不在JSON中返回
+	Password string `gorm:"type:text" json:"-"` // 密码/授权码加密存储，不在JSON中返回
 
 	// OAuth2信息
-	OAuth2Token string `gorm:"column:oauth2_token;type:text" json:"-"` // OAuth2 token（JSON格式，加密存储）
+	OAuth2Token string `gorm:"column:oauth2_token;type:text" json:"-"` // OAuth2 token（加密存储）
 
 	// 状态信息
 	IsActive     bool       `gorm:"not null;default:true" json:"is_active"`
@@ -47,6 +49,45 @@ type EmailAccount struct {
 	Emails  []Email     `gorm:"foreignKey:AccountID" json:"emails,omitempty"`
 	Folders []Folder    `gorm:"foreignKey:AccountID" json:"folders,omitempty"`
 	Group   *EmailGroup `gorm:"foreignKey:GroupID" json:"group,omitempty"`
+}
+
+
+// BeforeSave encrypts mailbox credentials before persisting.
+func (ea *EmailAccount) BeforeSave(tx *gorm.DB) error {
+	if ea.Password != "" {
+		encrypted, err := EncryptCredential(ea.Password)
+		if err != nil {
+			return err
+		}
+		ea.Password = encrypted
+	}
+	if ea.OAuth2Token != "" {
+		encrypted, err := EncryptCredential(ea.OAuth2Token)
+		if err != nil {
+			return err
+		}
+		ea.OAuth2Token = encrypted
+	}
+	return nil
+}
+
+// AfterFind decrypts mailbox credentials for in-memory provider use.
+func (ea *EmailAccount) AfterFind(tx *gorm.DB) error {
+	if ea.Password != "" {
+		decrypted, err := DecryptCredential(ea.Password)
+		if err != nil {
+			return err
+		}
+		ea.Password = decrypted
+	}
+	if ea.OAuth2Token != "" {
+		decrypted, err := DecryptCredential(ea.OAuth2Token)
+		if err != nil {
+			return err
+		}
+		ea.OAuth2Token = decrypted
+	}
+	return nil
 }
 
 // TableName 指定表名
@@ -70,8 +111,11 @@ func (ea *EmailAccount) SetOAuth2Token(token *OAuth2TokenData) error {
 	if err != nil {
 		return err
 	}
-	// TODO: 这里应该加密存储
-	ea.OAuth2Token = string(tokenBytes)
+	encrypted, err := EncryptCredential(string(tokenBytes))
+	if err != nil {
+		return err
+	}
+	ea.OAuth2Token = encrypted
 	return nil
 }
 
@@ -81,9 +125,13 @@ func (ea *EmailAccount) GetOAuth2Token() (*OAuth2TokenData, error) {
 		return nil, nil
 	}
 
-	// TODO: 这里应该解密
+	plainToken, err := DecryptCredential(ea.OAuth2Token)
+	if err != nil {
+		return nil, err
+	}
+
 	var token OAuth2TokenData
-	err := json.Unmarshal([]byte(ea.OAuth2Token), &token)
+	err = json.Unmarshal([]byte(plainToken), &token)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

This PR adds at-rest encryption for mailbox credentials stored by FireMail Plus.

Previously, `EmailAccount.OAuth2Token` was documented as encrypted, but the implementation stored the marshaled OAuth2 token JSON directly in SQLite with TODO comments for encryption/decryption. Password/app-password credentials were also persisted as plain text.

This change adds AES-GCM encryption for sensitive mailbox credentials before persistence and automatic decryption after loading accounts from the database.

## Changes

- Add credential encryption helpers using AES-GCM.
- Derive a 32-byte encryption key from `FIREMAIL_CREDENTIAL_KEY` / `CREDENTIAL_ENCRYPTION_KEY`, falling back to `JWT_SECRET` for compatibility.
- Encrypt `EmailAccount.Password` and `EmailAccount.OAuth2Token` before saving.
- Decrypt `EmailAccount.Password` and `EmailAccount.OAuth2Token` after loading, so provider code can continue using plaintext values in memory.
- Keep compatibility with already-encrypted values via the `enc:v1:` prefix.
- Keep plaintext legacy values readable so existing installations can migrate gradually.

## Security notes

- New deployments should set a strong, stable `FIREMAIL_CREDENTIAL_KEY`.
- Rotating this key requires a credential re-encryption/migration process.
- This PR protects credentials at rest in SQLite; it does not remove the need for filesystem, backup, and host-level security.

## Testing

- Built the Docker image successfully after patching.
- Verified the patched image starts correctly in Docker.
